### PR TITLE
Add cmake args to run integration test

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -50,6 +50,7 @@ jobs:
         base-url: ${{ env.BASE_URL }}
         title: ${{ env.TARGET_REPO }}
         ros-distro: ${{ env.ROS_DISTRO }}
+        extra-cmake-args: -DWITH_INTEGRATION_TEST=ON
         CCN: "20"
         CCN-recommendation: "10"
         nloc: "200"


### PR DESCRIPTION
With the following changes, integration tests can now be run with `colcon test`, so we will add a new argument.

https://github.com/tier4/scenario_simulator_v2/pull/529